### PR TITLE
v1.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/* \
  && gem install fluentd \
  && fluent-gem install  \
+  oj \
   fluent-mixin-config-placeholders \
   fluent-mixin-plaintextformatter \
   fluent-plugin-splunkhec:1.5 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.2
+FROM ruby:2.5.1
 
 RUN apt-get update \
  && apt-get install gettext-base --yes \
@@ -8,8 +8,8 @@ RUN apt-get update \
  && fluent-gem install  \
   fluent-mixin-config-placeholders \
   fluent-mixin-plaintextformatter \
-  fluent-plugin-splunkhec \
-  fluent-plugin-kubernetes_metadata_filter \
+  fluent-plugin-splunkhec:1.5 \
+  fluent-plugin-kubernetes_metadata_filter:1.0.1 \
   fluent-plugin-rewrite-tag-filter
 
 COPY docker-entrypoint /docker-entrypoint

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Specify your configuration in environment-variables like this:
 
 For a list of all options see: https://github.com/cmeerbeek/fluent-plugin-splunkhec
 
+### DEPRECATION NOTICE
+
+In previous versions it was required to configure the splunkhec plugin using something like `SPLUNK_HOST=example.com`. This functionality is deprecated and a warning will be printed. In the future this functionality will be completely removed.
+
 ## fluent-plugin-kubernetes_metadata_filter
 
 Specify your configuration in environment-variables like this:

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Original can be found [here](https://github.com/ziyasal/k8splunk)
 * Splunk HTTP Event Collector (HEC)-address
 * HEC-token
 * Kubernetes cluster and write access to the `logging`-namespace
-  - `kubectl create namespace logging`
+  * `kubectl create namespace logging`
 * When using `PodSecurityPolicy`s, make sure you grant the `fk8splunk` service-account access to use `hostPath` volume-mounts.
+  * `kubectl create rolebinding fk8splunk-privileged-psp --serviceaccount=logging:fk8splunk --clusterrole=privileged-psp`
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -44,3 +44,19 @@ kubectl apply -f https://raw.githubusercontent.com/missioncriticalkubernetes/fk8
 ```
 
 The forwarder will be configured with the value of `SPLUNKHEC_OPTION_token` from the `fk8splunk` secret.
+
+# Configuration
+
+## fluent-plugin-splunkhec
+
+Specify your configuration in environment-variables like this:
+  * `SPLUNKHEC_OPTION_host=example.com` becomes `host example.com` inside the output block in fluentd
+
+For a list of all options see: https://github.com/cmeerbeek/fluent-plugin-splunkhec
+
+## fluent-plugin-kubernetes_metadata_filter
+
+Specify your configuration in environment-variables like this:
+  * `K8S_METADATA_FILTER_OPTION_preserve_json_log=false` becomes `preserve_json_log false` inside the filter block in fluentd
+
+For a list of all options see: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ Original can be found [here](https://github.com/ziyasal/k8splunk)
 ## Fluentd log forwarder
 ```
 # export our Splunk HEC token (use your own)
-export SPLUNK_TOKEN="C2CE8936-73B5-4BBA-9EE2-312A70279AD3"
+export SPLUNKHEC_OPTION_token="C2CE8936-73B5-4BBA-9EE2-312A70279AD3"
 
 # Or generate a UUID to act as Splunk HEC token if you're using the Splunk forwarder below
 # For example, on MacOSX:
-export SPLUNK_TOKEN=$(uuidgen)
+export SPLUNKHEC_OPTION_token=$(uuidgen)
 
 # Create a secret to hold your Splunk configuration
-kubectl -n kube-system create secret generic fk8splunk --from-literal=SPLUNK_HOST=splunk.kube-system --from-literal=SPLUNK_PORT=8088 --from-literal=SPLUNK_INDEX=main --from-literal=SPLUNK_TOKEN=${SPLUNK_TOKEN}
+kubectl -n logging create secret generic fk8splunk --from-literal=SPLUNKHEC_OPTION_host=splunk.logging --from-literal=SPLUNKHEC_OPTION_port=8088 --from-literal=SPLUNKHEC_OPTION_index=main --from-literal=SPLUNKHEC_OPTION_token=${SPLUNKHEC_OPTION_token}
 
 # Install the daemonset
 kubectl apply -f https://raw.githubusercontent.com/missioncriticalkubernetes/fk8splunk/master/kubernetes/install-latest.yaml
@@ -42,4 +42,4 @@ Can't enable an HTTP Event Collector on your Splunk? Stuck with traditional forw
 kubectl apply -f https://raw.githubusercontent.com/missioncriticalkubernetes/fk8splunk/master/kubernetes/splunk-hec-forwarder.yaml
 ```
 
-The forwarder will be configured with the value of `SPLUNK_TOKEN` from the `fk8splunk` secret.
+The forwarder will be configured with the value of `SPLUNKHEC_OPTION_token` from the `fk8splunk` secret.

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -2,11 +2,20 @@
 
 set -eufo pipefail
 
+test -z ${DEBUG+x} || set -x
+
 # Transform deprecated options to new style options and print warning
 # 'SPLUNK_HOST=example.com' => 'SPLUNKHEC_OPTION_host=example.com'
 
 function splunkhec_compatability_options() {
-  for option in $(env | grep '^SPLUNK_'); do
+  local old_options=$(echo SPLUNK_{HOST,PROTOCOL,PORT,TOKEN,INDEX,EVENT_HOST,SOURCE,SOURCETYPE,SEND_EVENT_AS_JSON,USEJSON,SEND_BATCHED_EVENTS})
+  for old_option in $old_options; do
+    test -z ${!old_option+x} && continue
+
+    # SPLUNK_PORT might be set by Kubernetes. If it is, ignore it
+    [[ ${old_option} = "SPLUNK_PORT" ]] && [[ ${!old_option} =~ ^tcp:// ]] && continue
+
+    option=$(env | grep "^${old_option}=" | tail -n1)
     echo >&2 "WARNING: Deprecated option used. This will be removed in the future. Please use SPLUNKHEC_OPTION_key=value: '${option/=*/}'"
 
     option=${option/SPLUNK_/SPLUNKHEC_OPTION_}

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -69,7 +69,6 @@ function k8s_metadata_filter_final_options() {
 
 # Generate configuration and exec into fluentd
 
-splunk_deprecated_options
 splunkhec_compatability_options
 splunkhec_default_options
 splunkhec_final_options

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -2,16 +2,14 @@
 
 set -eufo pipefail
 
-function splunk_deprecated_options() {
-  for option in $(env | grep '^SPLUNK_'); do
-    echo >&2 "WARNING: Deprecated option used. This will be removed in the future. Please use SPLUNKHEC_OPTION_key=value: '${option/=*/}'"
-  done
-}
+# Transform deprecated options to new style options and print warning
+# 'SPLUNK_HOST=example.com' => 'SPLUNKHEC_OPTION_host=example.com'
 
 function splunkhec_compatability_options() {
   for option in $(env | grep '^SPLUNK_'); do
-    option=${option/SPLUNK_/SPLUNKHEC_OPTION_}
+    echo >&2 "WARNING: Deprecated option used. This will be removed in the future. Please use SPLUNKHEC_OPTION_key=value: '${option/=*/}'"
 
+    option=${option/SPLUNK_/SPLUNKHEC_OPTION_}
     key_upper=${option/SPLUNKHEC_OPTION_/}
     key_upper=${key_upper/=*/}
     key_lower=$(echo ${key_upper} | tr '[:upper:]' '[:lower:]')
@@ -21,8 +19,10 @@ function splunkhec_compatability_options() {
   done
 }
 
+# Set default options for splunkhec
+
 function splunkhec_default_options() {
-  export SPLUNKHEC_OPTION_host=${SPLUNKHEC_OPTION_host:-splunk.kube-system}
+  export SPLUNKHEC_OPTION_host=${SPLUNKHEC_OPTION_host:-splunk.logging}
   export SPLUNKHEC_OPTION_protocol=${SPLUNKHEC_OPTION_protocol:-https}
   export SPLUNKHEC_OPTION_port=${SPLUNKHEC_OPTION_port:-8088}
   export SPLUNKHEC_OPTION_token=${SPLUNKHEC_OPTION_token:-00000000-0000-0000-0000-000000000000}
@@ -30,6 +30,9 @@ function splunkhec_default_options() {
   export SPLUNKHEC_OPTION_send_event_as_json=${SPLUNKHEC_OPTION_send_event_as_json:-true}
   export SPLUNKHEC_OPTION_usejson=${SPLUNKHEC_OPTION_usejson:-true}
 }
+
+# Generate fluentd configuration for splunkhec
+# 'SPLUNKHEC_OPTION_host=example.com' => 'host example.com'
 
 function splunkhec_final_options() {
   SPLUNKHEC_OPTIONS=""
@@ -43,9 +46,14 @@ function splunkhec_final_options() {
   export SPLUNKHEC_OPTIONS
 }
 
+# Set default options for kubernetes_metadata_filter
+
 function k8s_metadata_filter_default_options() {
   export K8S_METADATA_FILTER_OPTION_preserve_json_log=${K8S_METADATA_FILTER_OPTION_preserve_json_log:-"false"}
 }
+
+# Generate fluentd configuration for kubernetes_metadata_filter
+# 'K8S_METADATA_FILTER_OPTION_preserve_json_log=false' => 'preserve_json_log false'
 
 function k8s_metadata_filter_final_options() {
   K8S_METADATA_FILTER_OPTIONS=""

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -2,18 +2,74 @@
 
 set -eufo pipefail
 
-export SPLUNK_HOST=${SPLUNK_HOST:-splunk.kube-system}
-export SPLUNK_PORT=${SPLUNK_PORT:-8088}
-export SPLUNK_PROTOCOL=${SPLUNK_PROTOCOL:-https}
-export SPLUNK_TOKEN=${SPLUNK_TOKEN:-00000000-0000-0000-0000-000000000000}
-export SPLUNK_INDEX=${SPLUNK_INDEX:-main}
-export SPLUNK_SOURCE=${SPLUNK_SOURCE:-fluentd}
-export SPLUNK_SOURCETYPE=${SPLUNK_SOURCETYPE:-kubernetes}
-export SPLUNK_USEJSON=${SPLUNK_USEJSON:-true}
-export SPLUNK_SEND_EVENT_AS_JSON=${SPLUNK_SEND_EVENT_AS_JSON:-true}
-export SPLUNK_SEND_BATCHED_EVENTS=${SPLUNK_SEND_BATCHED_EVENTS:-false}
+function splunk_deprecated_options() {
+  for option in $(env | grep '^SPLUNK_'); do
+    echo >&2 "WARNING: Deprecated option used. This will be removed in the future. Please use SPLUNKHEC_OPTION_key=value: '${option/=*/}'"
+  done
+}
+
+function splunkhec_compatability_options() {
+  for option in $(env | grep '^SPLUNK_'); do
+    option=${option/SPLUNK_/SPLUNKHEC_OPTION_}
+
+    key_upper=${option/SPLUNKHEC_OPTION_/}
+    key_upper=${key_upper/=*/}
+    key_lower=$(echo ${key_upper} | tr '[:upper:]' '[:lower:]')
+
+    option=${option/${key_upper}/${key_lower}}
+    export ${option}
+  done
+}
+
+function splunkhec_default_options() {
+  export SPLUNKHEC_OPTION_host=${SPLUNKHEC_OPTION_host:-splunk.kube-system}
+  export SPLUNKHEC_OPTION_protocol=${SPLUNKHEC_OPTION_protocol:-https}
+  export SPLUNKHEC_OPTION_port=${SPLUNKHEC_OPTION_port:-8088}
+  export SPLUNKHEC_OPTION_token=${SPLUNKHEC_OPTION_token:-00000000-0000-0000-0000-000000000000}
+  export SPLUNKHEC_OPTION_sourcetype=${SPLUNKHEC_OPTION_sourcetype:-kubernetes}
+  export SPLUNKHEC_OPTION_send_event_as_json=${SPLUNKHEC_OPTION_send_event_as_json:-true}
+  export SPLUNKHEC_OPTION_usejson=${SPLUNKHEC_OPTION_usejson:-true}
+}
+
+function splunkhec_final_options() {
+  SPLUNKHEC_OPTIONS=""
+
+  for option in $(env | grep '^SPLUNKHEC_OPTION_'); do
+    option=${option/SPLUNKHEC_OPTION_/}
+    option=${option/=/ }
+    SPLUNKHEC_OPTIONS=$(echo -e "${SPLUNKHEC_OPTIONS}\n  ${option}")
+  done
+
+  export SPLUNKHEC_OPTIONS
+}
+
+function k8s_metadata_filter_default_options() {
+  export K8S_METADATA_FILTER_OPTION_preserve_json_log=${K8S_METADATA_FILTER_OPTION_preserve_json_log:-"false"}
+}
+
+function k8s_metadata_filter_final_options() {
+  K8S_METADATA_FILTER_OPTIONS=""
+
+  for option in $(env | grep '^K8S_METADATA_FILTER_OPTION_'); do
+    option=${option/K8S_METADATA_FILTER_OPTION_/}
+    option=${option/=/ }
+    K8S_METADATA_FILTER_OPTIONS=$(echo -e "${K8S_METADATA_FILTER_OPTIONS}\n  ${option}")
+  done
+
+  export K8S_METADATA_FILTER_OPTIONS
+}
+
+# Generate configuration and exec into fluentd
+
+splunk_deprecated_options
+splunkhec_compatability_options
+splunkhec_default_options
+splunkhec_final_options
+
+k8s_metadata_filter_default_options
+k8s_metadata_filter_final_options
 
 confdir="/etc/td-agent"
 
-cat ${confdir}/td-agent.conf.template | envsubst '$SPLUNK_HOST $SPLUNK_PORT $SPLUNK_PROTOCOL $SPLUNK_TOKEN $SPLUNK_INDEX $SPLUNK_SOURCE $SPLUNK_SOURCETYPE $SPLUNK_USEJSON $SPLUNK_SEND_EVENT_AS_JSON $SPLUNK_SEND_BATCHED_EVENTS' > ${confdir}/td-agent.conf
+cat ${confdir}/td-agent.conf.template | envsubst '$K8S_METADATA_FILTER_OPTIONS $SPLUNKHEC_OPTIONS' > ${confdir}/td-agent.conf
 exec fluentd -c ${confdir}/td-agent.conf "$@"

--- a/kubernetes/install-latest.yaml
+++ b/kubernetes/install-latest.yaml
@@ -26,38 +26,38 @@ spec:
       serviceAccount: fk8splunk
       containers:
       - name: fk8splunk
-        image: missioncriticalkubernetes/fk8splunk:1.1.1
+        image: missioncriticalkubernetes/fk8splunk:1.2.0
         imagePullPolicy: Always
         args:
         - -q
         env:
-        - name: SPLUNK_HOST
+        - name: SPLUNKHEC_OPTION_host
           valueFrom:
             secretKeyRef:
               name: fk8splunk
-              key: SPLUNK_HOST
-        - name: SPLUNK_PORT
+              key: SPLUNKHEC_OPTION_host
+        - name: SPLUNKHEC_OPTION_port
           valueFrom:
             secretKeyRef:
               name: fk8splunk
-              key: SPLUNK_PORT
-        - name: SPLUNK_INDEX
+              key: SPLUNKHEC_OPTION_port
+        - name: SPLUNKHEC_OPTION_index
           valueFrom:
             secretKeyRef:
               name: fk8splunk
-              key: SPLUNK_INDEX
-        - name: SPLUNK_TOKEN
+              key: SPLUNKHEC_OPTION_index
+        - name: SPLUNKHEC_OPTION_token
           valueFrom:
             secretKeyRef:
               name: fk8splunk
-              key: SPLUNK_TOKEN
+              key: SPLUNKHEC_OPTION_token
         resources:
           requests:
-            cpu: 10m
-            memory: 256Mi
+            cpu: 200m
+            memory: 512Mi
           limits:
             cpu: 200m
-            memory: 256Mi
+            memory: 512Mi
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/kubernetes/splunk-hec-forwarder.yaml
+++ b/kubernetes/splunk-hec-forwarder.yaml
@@ -48,7 +48,7 @@ spec:
         command:
           - sh
           - -c
-          - echo "Initializing splunk with HEC-token"; echo -e "[http://fk8splunk-token]\ndescription=fk8splunk\ndisabled=0\nindex=main\ntoken=${SPLUNK_TOKEN}" > /init/inputs.conf
+          - echo "Initializing splunk with HEC-token"; echo -e "[http://fk8splunk-token]\ndescription=fk8splunk\ndisabled=0\nindex=main\ntoken=${SPLUNKHEC_OPTION_token}" > /init/inputs.conf
       containers:
       - name: splunk
         image: splunk/universalforwarder

--- a/kubernetes/splunk-hec-forwarder.yaml
+++ b/kubernetes/splunk-hec-forwarder.yaml
@@ -40,11 +40,11 @@ spec:
         - name: init-hec-inputs
           mountPath: /init
         env:
-        - name: SPLUNK_TOKEN
+        - name: SPLUNKHEC_OPTION_token
           valueFrom:
             secretKeyRef:
               name: fk8splunk
-              key: SPLUNK_TOKEN
+              key: SPLUNKHEC_OPTION_token
         command:
           - sh
           - -c

--- a/td-agent.conf.template
+++ b/td-agent.conf.template
@@ -282,18 +282,10 @@
 
 <filter kubernetes.**>
   @type kubernetes_metadata
+  $K8S_METADATA_FILTER_OPTIONS
 </filter>
 
 <match **>
   @type splunkhec
-  host $SPLUNK_HOST
-  port $SPLUNK_PORT
-  protocol $SPLUNK_PROTOCOL
-  token $SPLUNK_TOKEN
-  index $SPLUNK_INDEX
-  source $SPLUNK_SOURCE
-  sourcetype $SPLUNK_SOURCETYPE
-  usejson $SPLUNK_USEJSON
-  send_event_as_json $SPLUNK_SEND_EVENT_AS_JSON
-  send_batched_events $SPLUNK_SEND_BATCHED_EVENTS
+  $SPLUNKHEC_OPTIONS
 </match>


### PR DESCRIPTION
* bump kubernetes_metadata_filter plugin to v1.0.1 which includes fix to not spam the k8s api
* by default strip `log` field from splunk message when log is parsed as json
* more dynamic way of configuring kubernetes_metadata_filter and splunkhec
* install the oj gem for faster json parsing in fluentd
* maintain full backwards compatability; fk8splunk image can be upgraded without configuration changes